### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-
 ![banner](https://github.com/user-attachments/assets/eecc3b3f-313c-41aa-a28f-0c10b64d61b6)
 
 # What is DigitalFate?
+[![smithery badge](https://smithery.ai/badge/@Kalyankensin/DigitalFate)](https://smithery.ai/server/@Kalyankensin/DigitalFate)
+
 
 DigitalFate provides an advanced, enterprise-ready framework for orchestrating LLM calls, agents, and computer-based tasks in a cost-efficient manner. It delivers reliable systems, scalability, and a task-oriented architecture to handle real-world applications effectively.
 
@@ -30,6 +31,15 @@ DigitalFate provides an advanced, enterprise-ready framework for orchestrating L
 
 ## Installation
 
+### Installing via Smithery
+
+To install DigitalFate for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@Kalyankensin/DigitalFate):
+
+```bash
+npx -y @smithery/cli install @Kalyankensin/DigitalFate --client claude
+```
+
+### Installing Manually
 ```bash
 pip install digitalfate
 ```
@@ -242,3 +252,5 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ---
+
+

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,30 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - openaiApiKey
+      - anthropicApiKey
+    properties:
+      openaiApiKey:
+        type: string
+        description: The API key for OpenAI services.
+      anthropicApiKey:
+        type: string
+        description: The API key for Anthropic services.
+      awsAccessKeyId:
+        type: string
+        description: The AWS access key ID.
+      awsSecretAccessKey:
+        type: string
+        description: The AWS secret access key.
+      awsRegion:
+        type: string
+        description: The AWS region for Bedrock.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'docker', args: ['run', '--rm', '-e', `OPENAI_API_KEY=${config.openaiApiKey}`, '-e', `ANTHROPIC_API_KEY=${config.anthropicApiKey}`, '-e', `AWS_ACCESS_KEY_ID=${config.awsAccessKeyId || ''}`, '-e', `AWS_SECRET_ACCESS_KEY=${config.awsSecretAccessKey || ''}`, '-e', `AWS_REGION=${config.awsRegion || ''}`, 'digitalfate-image'] })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@Kalyankensin/DigitalFate?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂